### PR TITLE
feat: add a very simple extractor for tests

### DIFF
--- a/Command_Line_Interface.md
+++ b/Command_Line_Interface.md
@@ -81,7 +81,7 @@ This is a comprehensive list of the commands and flags you can use with `ezkl`. 
 And the flags (RunArgs) here:
 [!ref](/About_EZKL/RunArgs)
 
-```bash
+```
 Usage: ezkl [OPTIONS] <COMMAND>
 
 Commands:
@@ -134,7 +134,7 @@ Options:
 
 `prove` and `mock` both require `-D` and `-M` parameters. 
 
-```bash
+```
 Usage: ezkl mock [OPTIONS]
 
 Options:

--- a/extract.py
+++ b/extract.py
@@ -1,0 +1,20 @@
+# Run with something like:
+# python extract.py '../ezkl' '../ezkl-docs/Command_Line_Interface.md' | bash
+
+
+import sys
+#print(sys.argv)
+
+ezkl_path = sys.argv[1] #"../ezkl"
+doc_path = sys.argv[2] #'../ezkl-docs/Command_Line_Interface.md'
+
+with open(doc_path, 'r') as f:
+    in_code_block = False
+    for line in f:
+        stripped_line = line.strip()
+        if stripped_line.startswith('```'):
+            if ("ignore" not in stripped_line and stripped_line.startswith('```bash')) or in_code_block: 
+                in_code_block = not in_code_block
+        elif in_code_block:
+            stripped_line = stripped_line.replace("~/ezkl",ezkl_path)
+            print(stripped_line)


### PR DESCRIPTION
trivial code extractor to make doctests easier with something like
```bash
python extract.py '../ezkl' '../ezkl-docs/Command_Line_Interface.md' | bash
```