### PR TITLE
Remove rustup override nightly command.

### DIFF
--- a/Getting_Started.md
+++ b/Getting_Started.md
@@ -18,11 +18,6 @@ then download the repo and enter the directory
 git clone git@github.com:zkonduit/ezkl.git
 cd ezkl
 ```
-We require a specific nightly version of the rust toolchain. You can change the default toolchain by running:
-```bash
-rustup override set nightly-2023-04-16
-```
-
 After which you may build and install the library
 ```bash
 cargo install --force --path .


### PR DESCRIPTION
Rustup override nightly command is redundant b/c of toolchain file pointing to correct rust version.